### PR TITLE
Update link to commonmeta-py documentation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ _Later_: we plan to implement this format in a later release.
 
 ## Documentation
 
-Documentation (work in progress) for using the library is available at the [commonmeta-py Documentation](https://commonmeta-py.docs.front-matter.io) website and includes several interactive Jupyter Notebooks .
+Documentation (work in progress) for using the library is available at the [commonmeta-py Documentation](https://python.commonmeta.org/) website and includes several interactive Jupyter Notebooks .
 
 ## Meta
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Current docs link in README points to `https://commonmeta-py.docs.front-matter.io/`, which no longer resolves.  

Replaced with `https://python.commonmeta.org/`