### PR TITLE
Adding support for the OpenAlex Work Format

### DIFF
--- a/commonmeta/constants.py
+++ b/commonmeta/constants.py
@@ -464,6 +464,30 @@ CM_TO_SO_TRANSLATIONS = {
     "Presentation": "PresentationDigitalDocument",
 }
 
+# source: https://api.openalex.org/works?group_by=type
+OA_TO_CM_TRANSLATIONS = {
+    "article": "Article",
+    "book-chapter": "BookChapter",
+    "dataset": "Dataset",
+    "preprint": "Article",
+    "dissertation": "Dissertation",
+    "book": "Book",
+    "review": "Article",
+    "paratext": "Component",
+    "libguides": "InteractiveResource",
+    "letter": "Article",
+    "other": "Other",
+    "reference-entry": "Other",
+    "report": "Report",
+    "editorial": "Document",
+    "peer-review": "PeerReview",
+    "erratum": "Other",
+    "standard": "Standard",
+    "grant": "Grant",
+    "supplementary-materials": "Component",
+    "retraction": "Other"
+}
+
 SO_TO_DC_RELATION_TYPES = {
     "citation": "References",
     "isBasedOn": "IsSupplementedBy",
@@ -525,6 +549,16 @@ DC_TO_CM_CONTAINER_TRANSLATIONS = {
     "Proceedings": "ProceedingsSeries",
     "Repository": "Repository",
     "Series": "Series",
+}
+
+OA_TO_CM_CONTAINER_TRANLATIONS = {
+    "journal": "Journal",
+    "repository": "Repository",
+    "conference": "Proceedings",
+    "ebook platform": "Repository",
+    "book series": "BookSeries",
+    "metadata": "DataRepository",
+    "Other": "Repository"
 }
 
 DATACITE_CONTRIBUTOR_TYPES = {

--- a/commonmeta/doi_utils.py
+++ b/commonmeta/doi_utils.py
@@ -284,6 +284,16 @@ def datacite_api_sample_url(number: int = 1, **kwargs) -> str:
     return f"https://api.datacite.org/dois?random=true&page[size]={number}"
 
 
+def openalex_api_url(doi: str, **kwargs) -> str:
+    """Return the OpenAlex API URL for a given DOI"""
+    return f"https://api.openalex.org/works/{doi}"
+
+
+def openalex_api_sample_url(number: int = 1, **kwargs) -> str:
+    """Return the OpenAlex API URL for a sample of dois"""
+    return f"https://api.openalex.org/works?sample={number}"
+
+
 def is_rogue_scholar_doi(doi: str) -> bool:
     """Return True if DOI is from Rogue Scholar"""
     prefix = validate_prefix(doi)

--- a/commonmeta/metadata.py
+++ b/commonmeta/metadata.py
@@ -27,6 +27,10 @@ from .readers.codemeta_reader import (
     get_codemeta,
     read_codemeta,
 )
+from .readers.openalex_reader import (
+    get_openalex,
+    read_openalex,
+)
 from .readers.csl_reader import read_csl
 from .readers.cff_reader import get_cff, read_cff
 from .readers.json_feed_reader import get_json_feed_item, read_json_feed_item
@@ -140,6 +144,8 @@ class Metadata:
                 return get_json_feed_item(pid)
             elif via == "inveniordm":
                 return get_inveniordm(pid)
+            elif via == "openalex":
+                return get_openalex(pid)
         elif string is not None:
             if via == "datacite_xml":
                 return parse_xml(string)
@@ -197,6 +203,8 @@ class Metadata:
             return read_kbase(data)
         elif via == "ris":
             return read_ris(data)
+        elif via == "openalex":
+            return read_openalex(data)
         else:
             raise ValueError("No input format found")
 

--- a/commonmeta/readers/openalex_reader.py
+++ b/commonmeta/readers/openalex_reader.py
@@ -1,0 +1,284 @@
+"""crossref reader for commonmeta-py"""
+
+from typing import Optional
+import httpx
+from pydash import py_
+
+from ..utils import (
+    dict_to_spdx,
+    normalize_cc_url,
+    normalize_url,
+    normalize_doi,
+    normalize_issn,
+    issn_as_url,
+)
+from ..base_utils import wrap, compact, presence, sanitize, parse_attributes
+from ..author_utils import get_authors
+from ..date_utils import get_date_from_date_parts
+from ..doi_utils import (
+    doi_as_url,
+    doi_from_url,
+    openalex_api_sample_url,
+    openalex_api_url,
+)
+from ..constants import (
+    OA_TO_CM_CONTAINER_TRANLATIONS,
+    OA_TO_CM_TRANSLATIONS,
+    CR_TO_CM_CONTAINER_TRANSLATIONS,
+    CROSSREF_CONTAINER_TYPES,
+    Commonmeta,
+)
+
+def get_openalex(pid: str, **kwargs) -> dict:
+    """get_openalex"""
+    if pid is None:
+        return {"state": "not_found"}
+    url = openalex_api_url(pid)
+    response = httpx.get(url, timeout=10, **kwargs)
+    if response.status_code != 200:
+        return {"state": "not_found"}
+    return response.json() | {"via": "openalex"}
+
+def read_openalex(data: Optional[dict], **kwargs) -> Commonmeta:
+    """read_crossref"""
+    if data is None:
+        return {"state": "not_found"}
+    meta = data
+    # read_options = ActiveSupport::HashWithIndifferentAccess.
+    # new(options.except(:doi, :id, :url,
+    # :sandbox, :validate, :ra))
+    read_options = kwargs or {}
+
+    doi = meta.get("doi", None)
+    _id = doi_as_url(doi)
+    _type = OA_TO_CM_TRANSLATIONS.get(meta.get("type", None)) or "Other"
+
+    archive_locations = []
+
+    if meta.get("author", None):
+        contributors = get_authors(wrap(meta.get("authorships")), via="crossref")
+    else:
+        contributors = []
+
+    editors = []
+
+    url = normalize_url(compact({
+        py_.get(meta, "primary_location.landing_page_url")
+        or py_.get(meta, "id")
+        })
+        )
+    titles = [{
+                "title": sanitize(py_.get(meta, "title")),
+                "titleType": "Title",
+                }]
+    publisher = compact({"name": meta.get("primary_location.source.display_name", None)})
+    if _type == "Article" and py_.get(publisher, "name") == "Front Matter":
+        _type = "BlogPost"
+    date = compact(
+        {
+            "published": py_.get(meta, "publication_date")
+            or py_.get(meta, "created_date")
+        }
+    )
+    identifiers = [{
+        "identifier": pidurl_as_pid(str(uid)),
+        "identifierType": uidType.upper(),
+    } for uidType, uid in (py_.get(meta, "ids") or {}).items()]
+    
+    license_ = meta.get("license", None) #Returns string E.g. "cc-by"
+    if license_ is not None:
+        license_ = normalize_cc_url(license_[0].get("URL", None))
+        license_ = dict_to_spdx({"url": license_}) if license_ else None 
+        # Need clarification on how the final license should look 
+    issn = None
+    container = get_container(meta) # Todo
+    relations = []
+    references = [get_related(i) for i in get_references(meta.get("referenced_works", []))[:2]] #FTODO
+    funding_references = from_openalex_funding(wrap(meta.get("grants", None))) 
+
+    description = get_abstract(meta)
+    if description is not None:
+        descriptions = [{"description": sanitize(description), "type": "Abstract"}]
+    else:
+        descriptions = None
+
+    subjects = py_.uniq(
+        [
+            {"subject": py_.get(i,"subfield.display_name")}
+            for i in wrap(meta.get("topics", None))
+        ]
+    )
+
+    files = py_.uniq(
+        [
+        ]
+    )# Openalex has urls for openacess article pdfs where available but not any more that I can see
+     # Would files be used just for these urls?
+
+    return {
+        # required properties
+        "id": _id,
+        "type": _type,
+        # recommended and optional properties
+        "additionalType": None,
+        "archiveLocations": presence(archive_locations),
+        "container": presence(container),
+        "contributors": presence(contributors),
+        "date": presence(date),
+        "descriptions": presence(descriptions),
+        "files": presence(files),
+        "fundingReferences": presence(funding_references),
+        "geoLocations": None,
+        "identifiers": identifiers,
+        "language": meta.get("language", None),
+        "license": license_,
+        "provider": "OpenAlex",
+        "publisher": presence(publisher),
+        "references": presence(references),
+        "relations": presence(relations),
+        "subjects": presence(subjects),
+        "titles": presence(titles),
+        "url": url,
+        "version": meta.get("version", None),
+    } | read_options
+
+def pidurl_as_pid(pid):
+    """Strip url parts from OpenAlex pid"""
+    pid = str(pid)
+    parts = pid.split("/")
+    pid = "/".join(parts[3:]) if len(parts) > 3 else pid
+    return pid
+
+def get_abstract(meta):
+    """Parse abstract from OpenAlex abstract_inverted_index"""
+    abstract_inverted_index = py_.get(meta, "abstract_inverted_index")
+
+    if abstract_inverted_index:
+        # Determine the length of the abstract
+        max_pos = max(p for positions in abstract_inverted_index.values() for p in positions)
+        abstract_words = [''] * (max_pos + 1)
+
+        for word, positions in abstract_inverted_index.items():
+            for p in positions:
+                abstract_words[p] = word
+
+        abstract = ' '.join(abstract_words)
+    else:
+        abstract = ''
+
+def get_references(pids: list, **kwargs) -> list:
+    """Get related articles from OpenAlex using their pid
+       \n Used for retrieving metadata for citations and references which are not included in the OpenAlex record
+       \n Uses batches of 49 to meet their API limit of 50 pids per request"""
+    pid_batches = [pids[i:i+49] for i in range(0, len(pids), 49)]
+    
+    references = []
+    for pid_batch in pid_batches:
+        ids = "|".join(pid_batch)
+        url = f"https://api.openalex.org/works?filter=ids.openalex:{ids}"
+        response = httpx.get(url, timeout=10, **kwargs)
+        if response.status_code != 200:
+            return {"state": "not_found"}
+        response = response.json()
+        if py_.get(response,"count") == 0:
+            return {"state": "not_found"}
+            
+        references.extend(response.get("results"))
+
+    return references
+
+def get_citations(citation_url: str, **kwargs) -> list:
+    response = httpx.get(citation_url, timeout=10, **kwargs)
+    if response.status_code != 200:
+        return {"state": "not_found"}
+    response = response.json()
+    return response.json().get("results", [])
+
+def get_related(related: Optional[dict]) -> Optional[dict]:
+    """Get reference from OpenAlex reference"""
+    if related is None or not isinstance(related, dict):
+        return None
+    doi = related.get("doi", None)
+    print(doi)
+    metadata = {
+        "id": normalize_doi(doi) if doi else None,
+        "contributor": related.get("author", None),
+        "title": related.get("display_name", None),
+        "publisher": related.get("primary_location.source.host_organization_name", None),
+        "publicationYear": related.get("publication_year", None),
+        "volume": py_.get(related,"biblio.volume"),
+        "issue": py_.get(related,"biblio.issue"),
+        "firstPage": py_.get(related,"biblio.first_page"),
+        "lastPage": py_.get(related,"biblio.last_page"),
+        "containerTitle": related.get("primary_location.source.display_name", None),
+    }
+    return compact(metadata)
+
+def get_file(file: dict) -> dict:
+    """Get file from Crossref"""
+    return compact(
+        {
+            "url": file.get("URL", None),
+            "mimeType": file.get("content-type", None),
+        }
+    )
+
+def get_container(meta: dict) -> dict:
+    """Get container from Crossref"""
+    container = py_.get(meta,"primary_location")
+    container_source = container.get("source")
+    container_type = py_.get(container_source,"type")
+    container_type = OA_TO_CM_CONTAINER_TRANLATIONS.get(container_type, None)
+    issn = py_.get(container_source,"issn_l")
+    id = container.get("id")
+    container_title = container_source.get("display_name", None)
+    volume = py_.get(meta,"biblio.volume")
+    issue = py_.get(meta, "biblio.issue")
+    first_page = py_.get(meta,"biblio.first_page")
+    last_page = py_.get(meta, "biblio.last_page")
+
+    # TODO: add support for series, location, missing in Crossref JSON
+
+    return compact(
+        {
+            "type": container_type,
+            "identifier": issn or id,
+            "identifierType": "ISSN" if issn else "OpenAlexID",
+            "title": container_title,
+            "volume": volume,
+            "issue": issue,
+            "firstPage": first_page,
+            "lastPage": last_page,
+        }
+    )
+
+
+def from_openalex_funding(funding_references: list) -> list:
+    """Get funding references from OpenAlex"""
+    formatted_funding_references = []
+    for funding in funding_references:
+        f = compact(
+            {
+                "funderName": funding.get("funder_display_name", None),
+                "funderIdentifier": pidurl_as_pid(funding["funder"]),
+                "funderIdentifierType": "OpenAlex Funder ID",
+                "awardNumber": funding.get("award_id",None)
+            }
+        )
+        formatted_funding_references.append(f)
+    return py_.uniq(formatted_funding_references)
+
+
+def get_random_openalex_id(number: int = 1, **kwargs) -> list:
+    """Get random DOI from OpenAlex"""
+    number = 20 if number > 20 else number
+    url = openalex_api_sample_url(number, **kwargs)
+    try:
+        response = httpx.get(url, timeout=10)
+        if response.status_code != 200:
+            return []
+
+        items = py_.get(response.json(), "results")
+        return [i.get("doi") for i in items]
+    except (httpx.ReadTimeout, httpx.ConnectError):
+        return []


### PR DESCRIPTION
## Intro

Again, I just want to say I'm a big appreciator of how you wrote the library, its easy to understand and its been easy build onto.

The commonmeta format is something still relatively new to me. I had previously looked at using the DataCite format for storing my metadata with my own parsing, as a sort of ground truth, but I then discovered bolognese and then your library. They're invaluable, parsing between metadata formats should appear seamless for end users, but it does take a lot of groundwork and a solid common standard. 

## Onto the PR

After jumping into it I think I've managed to write a good draft for the reader and helper functions for working with the format.

To provide the functions, I just built off of your crossref_reader, as OpenAlex also provides metadata as JSON. Currently, the reader successfully retrieves the required items for the commonmeta format and returns a valid Metadata object, with just a few bits of metadata still missing.

### Current Additions:

- **`openalex_reader.py`**  
  - `get_openalex()`
  - `read_openalex()`
  - `get_random_openalex_id()`
  
- **`doi_utils.py`**  
  - `openalex_api_url()`
  - `openalex_api_sample_url()`
  
- **`constants.py`**  
  - `OA_TO_CM_TRANSLATIONS()`
  
- **`cli.py`**  
  - Added `"openalex"` as a provider

---

### Some Questions to complete the metadata:

1. **Commonmeta `files`**  
   OpenAlex offers good coverage for direct links to article PDFs. Would/could these go under files or somewhere else?

2. **Commonmeta `license`**  
   OpenAlex provides license data in shorthand (e.g., "cc-by"). I'm not sure what format commonmeta expects — this probably just needs a couple of straightforward function calls?

3. **OpenAlex `Citations`**  
   I expected either a citations field in the commonmeta format or a citedBy type in relatedTexts. I might be missing something obvious?


Feel free to mention any helper or processing functions I might have missed and Ill jump into writing them. Unit tests also need written but that might take me a couple days, I'll start once we have a good version.

---

### Quick Test

You can test the OpenAlex reader with the following code:

```python
from commonmeta.readers.openalex_reader import get_random_openalex_id
from commonmeta.metadata import Metadata

pid = get_random_openalex_id()[0]
metadata = Metadata(pid, via="openalex")
```