### PR TITLE
Fix publicationYear typo in DataCite doc notebook

### DIFF
--- a/docs/readers/datacite_reader.ipynb
+++ b/docs/readers/datacite_reader.ipynb
@@ -57,7 +57,7 @@
     "* `titles`: the title(s) of the resource\n",
     "* `creators`: the creator(s)/author(s) of the resource\n",
     "* `publisher`: the publisher of the resource\n",
-    "* `publication_year`: the publication year of the resource\n",
+    "* `publicationYear`: the publication year of the resource\n",
     "\n",
     "In addition, there are plenty of optional metadata. They are converted into the standardized commonmeta format used internally. This format is close to the metadata format used by DataCite."
    ]


### PR DESCRIPTION
Just noticed this typo, the correct field is publicationYear rather than publication_year