### PR TITLE
Correct typo - Other to other

### DIFF
--- a/commonmeta/writers/inveniordm_writer.py
+++ b/commonmeta/writers/inveniordm_writer.py
@@ -36,7 +36,7 @@ def write_inveniordm(metadata):
     """Write inveniordm"""
     if metadata is None or metadata.write_errors is not None:
         return None
-    _type = CM_TO_INVENIORDM_TRANSLATIONS.get(metadata.type, "Other")
+    _type = CM_TO_INVENIORDM_TRANSLATIONS.get(metadata.type, "other")
     creators = [
         to_inveniordm_creator(i)
         for i in wrap(metadata.contributors)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
I changed the value for the resource_type from "Other" to "other", because invenio needs a lowercase letter and in the other two cases "other" (line 49 and 98) is written with lowercase letters

## Related Issue
I did not open a issue for this.

## Example
`# Add the path of commonmeta-py to sys.path`
`sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), 'commonmeta-py')))`
`import commonmeta as commonmeta`
`# DOI from datacite of the website https://journaldata.zbw.eu`
`doi = "10.15456/j1.2025210.1943358304"`
`metadata_obj = commonmeta.metadata.Metadata(doi, via = "datacite")`
`# Control if the data are right`
`metadata_datacite = metadata_obj.write(to = "datacite")`
`print(metadata_datacite)`
`# Convert the data to invenio rdm format`
`metadata_inveniordm = metadata_obj.write(to = "inveniordm")`
`print(metadata_inveniordm)`